### PR TITLE
File output should not be cached.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -141,6 +141,7 @@ if ( in_array(
 		array(
 			'wp-app.php',
 			'xmlrpc.php',
+			'ms-files.php',
 		) ) )
 	return;
 


### PR DESCRIPTION
I run a WordPress Network behind Varnish. I'm seeing situations where some link in that chain is mangling file downloads. Is it ever appropriate for batcache to cache file output? Some of these files can be very large.
