### PR TITLE
only cache GET requests

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -149,8 +149,8 @@ if ( in_array(
 if ( strstr( $_SERVER['SCRIPT_FILENAME'], 'wp-includes/js' ) )
 	return;
 
-// Never batcache when POST data is present.
-if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) )
+// Only batcache GET requests
+if ( ! empty( $_SERVER['REQUEST_METHOD'] != "GET" )
 	return;
 
 // Never batcache when cookies indicate a cache-exempt visitor.

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -150,7 +150,7 @@ if ( strstr( $_SERVER['SCRIPT_FILENAME'], 'wp-includes/js' ) )
 	return;
 
 // Only batcache GET requests
-if ( ! empty( $_SERVER['REQUEST_METHOD'] != "GET" )
+if ( $_SERVER['REQUEST_METHOD'] != "GET" )
 	return;
 
 // Never batcache when cookies indicate a cache-exempt visitor.


### PR DESCRIPTION
While doing load tests we noticed that `ab` was hitting this condition and not being cached. Apparently it is including some POST data in the GET request (maybe just some white space or newline?)

It seems to me that batcache should only be caching GET requests anyways. So this commit just checks the request method.