### PR TITLE
Prevent "undefined property" notice. See #2

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -32,6 +32,8 @@ class batcache {
 
 	var $cancel = false; // Change this to cancel the output buffer. Use batcache_cancel();
 
+	var $do = false; // By default, we do not cache
+
 	function batcache( $settings ) {
 		if ( is_array( $settings ) ) foreach ( $settings as $k => $v )
 			$this->$k = $v;


### PR DESCRIPTION
The notice in question:

```
PHP Notice:  Undefined property: batcache::$do in /w/wp-content/batcache/advanced-cache.php on line 245
```

My setup did not produce a notice around `$genlock`.
