### PR TITLE
Make $url_key protocol aware

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -239,7 +239,8 @@ if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
 }
 
 // Recreate the permalink from the URL
-$batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
+$protocol = ( isset( $batcache->keys['ssl'] ) && true === $batcache->keys['ssl'] ) ? 'https://' : 'http://';
+$batcache->permalink = $protocol . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
 $batcache->url_key = md5($batcache->permalink);
 $batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
 


### PR DESCRIPTION
When using SSL, keys can get out of sync due to the $url_key not being protocol aware. In batcache.php, `batcache_clear_url()` increments the cache version using the URL provided by `get_permalink()`, which accounts for the protocol. Unfortunately, `advanced-cache.php` generates $url_key using a hardcoded, "http://" protocol. While `batcache_clear_url()` bumped the version of the cache, it is unrecognized since a different URL is used to check the version.

This patch makes the check in advanced-cache.php protocol aware, thereby fixing problems on SSL sites with cache invalidation.