### PR TITLE
Notice level error in $three04

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -494,7 +494,7 @@ if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcac
 
 	$batcache->do_headers( $batcache->headers, $batcache->cache['headers'] );
 
-	if ( $three04 ) {
+	if ( isset($three04) && $three04 === true ) {
 		header("HTTP/1.1 304 Not Modified", true, 304);
 		die;
 	}


### PR DESCRIPTION
$three04 is never set to false anywhere, and is not initialized properly in all conditions. This check makes sure the variable is set
