### PR TITLE
Fix for Undefined property: batcache::$do

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -417,6 +417,11 @@ if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
 		else
 			$batcache->do = false;
 	}
+	else
+	{
+		//Don't cache if we found item in cache
+		$batcache->do = false;
+	}
 }
 
 // If the document has been updated and we are the first to notice, regenerate it.


### PR DESCRIPTION
```
Notice: Undefined property: batcache::$do in /var/www/site/wp-content/advanced-cache.php on line 428
```

This is because the variable is not always properly initialized. This change makes sure it is. I'm pretty sure the logic is correct but please double check.
