### PR TITLE
Issue #35 Fix the $batcache::query "undefined property" notice.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -388,7 +388,7 @@ $batcache->keys = array(
 	'host' => $_SERVER['HTTP_HOST'],
 	'method' => $_SERVER['REQUEST_METHOD'],
 	'path' => ( $batcache->pos = strpos($_SERVER['REQUEST_URI'], '?') ) ? substr($_SERVER['REQUEST_URI'], 0, $batcache->pos) : $_SERVER['REQUEST_URI'],
-	'query' => $batcache->query,
+	'query' => ( isset($batcache->query) ) ? $batcache->query : '',
 	'extra' => $batcache->unique
 );
 


### PR DESCRIPTION
As described in the Issue, as the property is not set somewhere in the script, the if generates the notice of undefined variable.

With the if statement, the notice, obviously, disappears.