### PR TITLE
eliminate a PHP Notice

### DIFF
--- a/batcache.php
+++ b/batcache.php
@@ -9,7 +9,7 @@ Version: 1.2
 */
 
 // Do not load if our advanced-cache.php isn't loaded
-if ( ! is_object($batcache) || ! method_exists( $wp_object_cache, 'incr' ) )
+if ( ! isset( $batcache ) || ! is_object($batcache) || ! method_exists( $wp_object_cache, 'incr' ) )
 	return;
 
 $batcache->configure_groups();


### PR DESCRIPTION
The notice is especially annoying when using WP-CLI
