### PR TITLE
Version update should force cache refresh.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -398,16 +398,19 @@ if ( $batcache->is_ssl() )
 // Recreate the permalink from the URL
 $batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
 $batcache->url_key = md5($batcache->permalink);
-$batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
 $batcache->configure_groups();
+$batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
 $batcache->do_variants();
 $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
 
-// Are we only caching frequently-requested pages?
-if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
+if ( isset($batcache->cache['version']) && $batcache->cache['version'] < $batcache->url_version ) {
+	// Always refresh the cache if a newer version is available.
+	$batcache->do = true;
+} else if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
+	// Are we only caching frequently-requested pages?
 	$batcache->do = true;
 } else {
 	// No batcache item found, or ready to sample traffic again at the end of the batcache life?
@@ -423,7 +426,7 @@ if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
 }
 
 // If the document has been updated and we are the first to notice, regenerate it.
-if ( $batcache->do !== false && isset($batcache->cache['version']) && $batcache->cache['version'] < $batcache->url_version )
+if ( $batcache->do )
 	$batcache->genlock = wp_cache_add("{$batcache->url_key}_genlock", 1, $batcache->group, 10);
 
 // Temporary: remove after 2010-11-12. I added max_age to the cache. This upgrades older caches on the fly.


### PR DESCRIPTION
Here's a fix for https://github.com/Automattic/batcache/issues/37

This PR also fixes the related problem of cached content not being refreshed after posts are updated. More discussion of the problem can be found in this ticket: https://wordpressvip.zendesk.com/requests/39366