### PR TITLE
Move the debug comments from the top to the bottom

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -302,7 +302,7 @@ HTML;
 		if ( false === $head_position ) {
 			return;
 		}
-		$this->cache['output'] = substr_replace( $this->cache['output'], $debug_html, $head_position, 0 );
+		$this->cache['output'] .= "\n$debug_html";
 	}
 }
 


### PR DESCRIPTION
Currently batcache outputs debug HTML comments at top of the page. I’d like to move that to the bottom of the page ( below the closing </html> tag ).

Browsers are getting more and more aggressive about scanning the HTML source looking for additional resources that page is going to load. In some cases the hints to the browser pre-loader only work if the hint is near the very top of the page. Since the batcache comments aren’t critical to rendering the page, I propose they should be moved from the top of the page to the bottom.

I’ve run several tests and have had no problems with the comments being at the end. WP-Super-Cache puts the debug comments at the bottom as well.

The current code looks for the HEAD tag and puts the debug comments directly above it. I didn’t remove that check in my change because it seemed like one more safety check to make sure this was HTML output.
