### PR TITLE
Add lookbehind to allow sprintf in variant determiner.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -29,7 +29,7 @@ function batcache_cancel() {
 function vary_cache_on_function($function) {
 	global $batcache;
 
-	if ( preg_match('/include|require|echo|print|dump|export|open|sock|unlink|`|eval/i', $function) )
+	if ( preg_match('/include|require|echo|(?<!s)print|dump|export|open|sock|unlink|`|eval/i', $function) )
 		die('Illegal word in variant determiner.');
 
 	if ( !preg_match('/\$_/', $function) )


### PR DESCRIPTION
sprintf() isn't an output function so should be allowed. It's also necessary for things like getting an unsigned int value from ip2long() on 32bit systems (like vip-quickstart).