### PR TITLE
Added `batcache` hook

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -153,6 +153,9 @@ class batcache {
 	}
 
 	function ob($output) {
+		
+		do_action( 'batcache', $this );
+		
 		if ( $this->cancel !== false )
 			return $output;
 


### PR DESCRIPTION
Added `batcache` action so we can configure Batcache, without hacking advanced-cache.php or wp-config.php. Not really needed as we can just update the $batcache global but this is a nice WordPressy way of doing it.

-- Zac