### PR TITLE
check for DONOTCACHEPAGE before caching

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -153,7 +153,7 @@ class batcache {
 	}
 
 	function ob($output) {
-		if ( $this->cancel !== false )
+		if ( $this->cancel !== false || defined('DONOTCACHEPAGE') && DONOTCACHEPAGE )
 			return $output;
 
 		// PHP5 and objects disappearing before output buffers?


### PR DESCRIPTION
Allows plugins like WooCommerce that set the DONOTCACHEPAGE constant to prevent batcache from caching the current request. Implements #26 