### PR TITLE
Block Batcache when REQUEST_METHOD is POST

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -326,9 +326,10 @@ if ( in_array(
 if ( strstr( $_SERVER['SCRIPT_FILENAME'], 'wp-includes/js' ) )
 	return;
 
-// Never batcache when POST data is present.
-if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) )
+// Never batcache a POST request.
+if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) || ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) ) {
 	return;
+}
 
 // Never batcache when cookies indicate a cache-exempt visitor.
 if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) ) {


### PR DESCRIPTION
Knowing that Batcache does not run on POST requests, I was surprised to find that Batcache was sending back its headers on a request such as:

```bash
 curl -i -X POST -d '' http://vip.local/api-endpoint/
```

Batcache should be blocked on requests such as this, even when the POST data is empty,