### PR TITLE
Facilitate debugging HTML fragments

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -64,6 +64,8 @@ class batcache {
 
 	var $debug   = true; // Set false to hide the batcache info <!-- comment -->
 
+	var $debug_html_fragments = false; // Set to true to amend batcache info to HTML fragments (that don't contain <head>)
+
 	var $cache_control = true; // Set false to disable Last-Modified and Cache-Control headers
 
 	var $cancel = false; // Change this to cancel the output buffer. Use batcache_cancel();
@@ -309,7 +311,7 @@ HTML;
 		}
 
 		$head_position = strpos( $this->cache['output'], '<head' );
-		if ( false === $head_position ) {
+		if ( false === $head_position && ! $this->debug_html_fragments ) {
 			return;
 		}
 		$this->cache['output'] .= "\n$debug_html";


### PR DESCRIPTION
We're working on a site that uses ESI includes to render load HTML fragments onto a host page, where the host page has a longer `max_age` than the fragments it includes and/or where we call `batcache_clear_url()` on the fragment URLs when they need to be updated immediately.

It is very useful to have the Batcache debugging comment amended to these HTML fragments, even though they lack a `<head>` tag in them.

This change allows the debug comment to be amended to any HTML response.