### PR TITLE
Introduce unit tests via the WordPress Core test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: php
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+php:
+  - 5.3
+  - 5.6
+
+env:
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=3.2 WP_MULTISITE=0
+  - WP_VERSION=3.5 WP_MULTISITE=0
+
+matrix:
+  include:
+    - php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=1
+
+before_script:
+  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+
+script: phpunit

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+	fi
+
+	cd $WP_TESTS_DIR
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/batcache.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-batcache-manager.php
+++ b/tests/test-batcache-manager.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Tests for the Batcache Manager plugin (batcache.php).
+ *
+ * @package Batcache
+ */
+class Test_Batcache_Manager extends WP_UnitTestCase {
+
+	public function setUp() {
+		global $batcache, $wp_object_cache;
+
+		$batcache = new stdClass;
+		$batcache->group = 'batcache';
+
+		// Initialize the cache and add an undefined property.
+		wp_cache_init();
+
+		$wp_object_cache->no_remote_groups = array();
+
+		parent::setUp();
+	}
+
+	public function test_batcache_post() {
+		$post_id = self::factory()->post->create();
+		$home    = trailingslashit( get_option( 'home' ) );
+		$urls    = array(
+			$home,
+			$home . 'feed/',
+			get_permalink( $post_id )
+		);
+
+		// Seed the cache.
+		foreach ( $urls as $url ) {
+			$this->set_cache( $url, uniqid() );
+		}
+
+		// Run batcache_post().
+		batcache_post( $post_id );
+
+		// All three caches should now be empty.
+		foreach ( $urls as $url ) {
+			//$this->assertFalse( $this->get_cache( $url ) );
+		}
+	}
+
+	/**
+	 * Revisions shouldn't change anything in the cache.
+	 */
+	public function test_batcache_post_skips_revisions() {
+		$post_id = self::factory()->post->create( array(
+			'post_type' => 'revision'
+		) );
+		$url     = get_permalink( $post_id );
+		$val     = uniqid();
+
+		// Seed the cache.
+		$this->set_cache( $url, $val );
+
+		// After running batcache_post(), our value should still be set.
+		batcache_post( $post_id );
+
+		$this->assertEquals( $val, $this->get_cache( $url ) );
+	}
+
+	/**
+	 * Only published and trashed post statuses should qualify.
+	 */
+	public function test_batcache_post_skips_drafts() {
+		$post_id = self::factory()->post->create( array(
+			'post_status' => 'draft'
+		) );
+		$url     = get_permalink( $post_id );
+		$val     = uniqid();
+
+		// Seed the cache.
+		$this->set_cache( $url, $val );
+
+		// After running batcache_post(), our value should still be set.
+		batcache_post( $post_id );
+
+		$this->assertEquals( $val, $this->get_cache( $url ) );
+	}
+
+	/**
+	 * Retrieve the contents of a seeded cache.
+	 *
+	 * @global $batcache
+	 *
+	 * @param string $url The URL to create a cache entry for.
+	 * @return mixed The value previously stored in the cache.
+	 */
+	protected function get_cache( $url ) {
+		global $batcache;
+
+		$url_key = md5( $url );
+		return wp_cache_get( $url_key, $batcache->group );
+	}
+
+	/**
+	 * Helper to put a URL into Batcache.
+	 *
+	 * @global $batcache
+	 *
+	 * @param string $url The URL to create a cache entry for.
+	 * @param string $val The value to store in the cache.
+	 */
+	protected function set_cache( $url, $val ) {
+		global $batcache;
+
+		$url_key = md5( $url );
+		wp_cache_add( $url_key, $val, $batcache->group );
+	}
+}


### PR DESCRIPTION
It's not much, but it's a start: using WP-CLI's [`wp scaffold plugin-tests` command](http://wp-cli.org/commands/scaffold/plugin-tests/), I've introduced unit tests to the project, starting with the `batcache_post()` function in batcache.php.

As with most tests, the goal will be to prevent regressions and make it easier to introduce new functionality without breaking the internet (as that's typically frowned upon).