### PR TITLE
Only cache GET or HEAD. Closes #67.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -337,10 +337,8 @@ if ( in_array(
 if ( strstr( $_SERVER['SCRIPT_FILENAME'], 'wp-includes/js' ) )
 	return;
 
-// Never batcache a POST request.
-if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) ||
-	( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) )
-{
+// Only cache HEAD and GET requests.
+if ((isset($_SERVER['REQUEST_METHOD']) && !in_array($_SERVER['REQUEST_METHOD'], array('GET', 'HEAD')))) {
 	return;
 }
 


### PR DESCRIPTION
For WP-API, POST, PUT, DELETE, and PURGE requests are cached, which makes things difficult.
