### PR TITLE
Use __construct

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -74,7 +74,7 @@ class batcache {
 	var $genlock = false;
 	var $do = false;
 
-	function batcache( $settings ) {
+	function __construct( $settings ) {
 		if ( is_array( $settings ) ) foreach ( $settings as $k => $v )
 			$this->$k = $v;
 	}


### PR DESCRIPTION
Fixes error `Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; batcache has a deprecated constructor in .../wp-content/advanced-cache.php on line 41`