### PR TITLE
Compat with WP 4.7

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -537,8 +537,16 @@ if ( isset( $batcache->cache['time'] ) && // We have cache
 if ( ! $batcache->do || ! $batcache->genlock )
 	return;
 
-$wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 2 );
-$wp_filter['wp_redirect_status'][10]['batcache'] = array( 'function' => array(&$batcache, 'redirect_status'), 'accepted_args' => 2 );
+
+if ( ! isset( $wp_filter['status_header'] ) ) {
+    $wp_filter['status_header'] = new WP_Hook();
+}
+$wp_filter['status_header']->callbacks[10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 2 );
+
+if ( ! isset( $wp_filter['wp_redirect_status'] ) ) {
+    $wp_filter['wp_redirect_status'] = new WP_Hook();
+}
+$wp_filter['wp_redirect_status']->callbacks[10]['batcache'] = array( 'function' => array(&$batcache, 'redirect_status'), 'accepted_args' => 2 );
 
 ob_start(array(&$batcache, 'ob'));
 


### PR DESCRIPTION
The previous behavior of batcache follows the first example described in the [Make blog post](https://make.wordpress.org/core/2016/09/08/wp_hook-next-generation-actions-and-filters/) regarding `WP_Hook`.
I'm not sure why this manual setting of callbacks in `$wp_filter` is necessary; perhaps it was purely unintentional. If that's the case, using `add_action`/`add_filter` are always preferred.