### PR TITLE
Set page gen time to request start if possible

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -185,7 +185,7 @@ class batcache {
 		// Construct and save the batcache
 		$this->cache = array(
 			'output' => $output,
-			'time' => time(),
+			'time' => isset( $_SERVER['REQUEST_TIME'] ) ? $_SERVER['REQUEST_TIME'] : time(),
 			'timer' => $this->timer_stop(false, 3),
 			'headers' => array(),
 			'status_header' => $this->status_header,


### PR DESCRIPTION
When we use `time()` as the cached page generation time after it's been
generated it's possible for the generation time to be a second or more after
the page request time. The cached response generation time is used for the HTTP
`last-modified` header so when this happens it's set to a date-time that's
after the `date` HTTP header. (Resource generated in future issue.)

This is non-compliant and may cause browsers and revers proxies to not cache
the resource properly.
