### PR TITLE
Don't use get_post() when cleaning post cache, use already passed $post object

### DIFF
--- a/batcache.php
+++ b/batcache.php
@@ -15,18 +15,17 @@ if ( ! isset( $batcache ) || ! is_object($batcache) || ! method_exists( $wp_obje
 $batcache->configure_groups();
 
 // Regen home and permalink on posts and pages
-add_action('clean_post_cache', 'batcache_post');
+add_action('clean_post_cache', 'batcache_post', 10, 2);
 
 // Regen permalink on comments (TODO)
 //add_action('comment_post',          'batcache_comment');
 //add_action('wp_set_comment_status', 'batcache_comment');
 //add_action('edit_comment',          'batcache_comment');
 
-function batcache_post($post_id) {
+function batcache_post($post_id, $post = null) {
 	global $batcache;
 
-	$post = get_post($post_id);
-	if ( $post->post_type == 'revision' || ! in_array( get_post_status($post_id), array( 'publish', 'trash' ) ) )
+	if ( ! $post || $post->post_type == 'revision' || ! in_array( get_post_status($post_id), array( 'publish', 'trash' ) ) )
 		return;
 
 	$home = trailingslashit( get_option('home') );

--- a/batcache.php
+++ b/batcache.php
@@ -25,6 +25,11 @@ add_action('clean_post_cache', 'batcache_post', 10, 2);
 function batcache_post($post_id, $post = null) {
 	global $batcache;
 
+	// Get the post for backwards compatibility with earlier versions of WordPress
+	if ( ! $post ) {
+		$post = get_post( $post_id );	
+	}
+	
 	if ( ! $post || $post->post_type == 'revision' || ! in_array( get_post_status($post_id), array( 'publish', 'trash' ) ) )
 		return;
 


### PR DESCRIPTION
This avoids problems when a post has already been deleted and then it calls `clean_post_cache( $post )` which then produces the problem when trying to call `get_post( $post_id )`

`PHP Notice: Trying to get property of non-object`
