### PR TITLE
Enable specific script filenames to be excluded from Batcache

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -62,6 +62,8 @@ class batcache {
 	var $use_stale        = true; // Is it ok to return stale cached response when updating the cache?
 	var $uncached_headers = array('transfer-encoding'); // These headers will never be cached. Apply strtolower.
 
+	var $uncached_files = array(); // Script filenames that should never be cached.
+
 	var $debug   = true; // Set false to hide the batcache info <!-- comment -->
 
 	var $cache_control = true; // Set false to disable Last-Modified and Cache-Control headers
@@ -326,11 +328,11 @@ if ( ! defined( 'WP_CONTENT_DIR' ) )
 // Never batcache interactive scripts or API endpoints.
 if ( in_array(
 		basename( $_SERVER['SCRIPT_FILENAME'] ),
-		array(
+		array_merge( array(
 			'wp-app.php',
 			'xmlrpc.php',
 			'wp-cron.php',
-		) ) )
+		), (array) $batcache->uncached_files ) ) );
 	return;
 
 // Never batcache WP javascript generators


### PR DESCRIPTION
This PR adds a new property to the Batcache object, `$uncached_files`, which is an array of script filenames. Later, when Batcache is returning early for specific filenames (under the "Never batcache interactive scripts or API endpoints." comment), this optional array of filenames is merged in.

In practice, this would allow pages like `wp-login.php` or any custom, interactive endpoint be excluded from Batcache via `wp-config.php`, foregoing the need to modify the `advanced-cache.php` file directly.

## Example usage

```php
# wp-config.php

global $batcache;

$batcache = array(
  'uncached_files' => array( 'wp-login.php', 'my-custom-script.php' ),
);
```