### PR TITLE
Use negative lookahead to allow openssl_* functions

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -29,7 +29,7 @@ function batcache_cancel() {
 function vary_cache_on_function($function) {
 	global $batcache;
 
-	if ( preg_match('/include|require|echo|(?<!s)print|dump|export|open|sock|unlink|`|eval/i', $function) )
+	if ( preg_match('/include|require|echo|(?<!s)print|dump|export|open(?!ssl)|sock|unlink|`|eval/i', $function) )
 		die('Illegal word in variant determiner.');
 
 	if ( !preg_match('/\$_/', $function) )


### PR DESCRIPTION
The `vary_cache_on_function` method [will disallow](https://github.com/Automattic/batcache/blob/6c222ff6ce0fc4eef495fd16f6b764e72878e5d6/advanced-cache.php#L32) all functions containing the substring `open`. This is likely to prevent the user from creating functions that use `fopen`, `opendir` and similar. However it also prevents users from using all functions from the `openssl_*` family.

Our use case is the following:

* On a VIP site we want to differentiate cache variants for premium and non-premium users.
* We want to be able to use [`openssl_decrypt`](http://php.net/manual/en/function.openssl-decrypt.php) to decrypt a userdata cookie and then we set the variant based on whether the current user has purchased a subscription or not.

This PR adds a negative lookahead to allow the `openssl_*` functions inside `vary_cache_on_function`.