### PR TITLE
Normalize GET parameter order

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -393,8 +393,12 @@ if ( ! method_exists( $GLOBALS['wp_object_cache'], 'incr' ) )
 header('Vary: Cookie', false);
 
 // Things that define a unique page.
-if ( isset( $_SERVER['QUERY_STRING'] ) )
+if ( isset( $_SERVER['QUERY_STRING'] ) ) {
 	parse_str($_SERVER['QUERY_STRING'], $batcache->query);
+
+	// Normalize query paramaters for better cache hits.
+	ksort( $batcache->query );
+}
 
 $batcache->keys = array(
 	'host' => $_SERVER['HTTP_HOST'],


### PR DESCRIPTION
Most requests with query parameters bypass Batcache, but for WordPress REST API requests, query parameters are cached as well, but with a different cache for each unique order of query parameters. If we normalize the query parameter order, we can potentially have a higher number of cache hits.

props: @emrikol