### PR TITLE
Add in a variable that was undefined by default

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -55,6 +55,7 @@ class batcache {
 
 	var $headers = array(); // Add headers here as name=>value or name=>array(values). These will be sent with every response from the cache.
 
+	var $status_header   = false;
 	var $cache_redirects = false; // Set true to enable redirect caching.
 	var $redirect_status = false; // This is set to the response code during a redirect.
 	var $redirect_location = false; // This is set to the redirect location.


### PR DESCRIPTION
I kept seeing issues with error log entries about an undefined `batcache::$status_header`, and adding this fixed it