### PR TITLE
Don't cache requests that have a `X-WP-Nonce` header

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -362,6 +362,11 @@ if ((isset($_SERVER['REQUEST_METHOD']) && !in_array($_SERVER['REQUEST_METHOD'], 
 	return;
 }
 
+// Never batcache a request with X-WP-Nonce header.
+if ( ! empty( $_SERVER['HTTP_X_WP_NONCE'] ) ) {
+	return;
+}
+
 // Never batcache when cookies indicate a cache-exempt visitor.
 if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) ) {
 	foreach ( array_keys( $_COOKIE ) as $batcache->cookie ) {


### PR DESCRIPTION
Because, cache pollution. :)

To test, run this command a few times:
```
curl 'https://vubuesinessplantest.help/wp-json/' -H 'x-wp-nonce: nope' -vs | grep nonce
```
and then see the cached response for
```
curl 'https://vubuesinessplantest.help/wp-json/' -vs | grep nonce
```