### PR TITLE
Fix to correctly serve cached pages if we're caching on first visit.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -455,7 +455,7 @@ $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
-$is_cached = ! empty( $batcache->cache );
+$is_cached = ! is_array( $batcache->cache );
 $has_expired = $is_cached && time() > $batcache->cache['time'] + $batcache->cache['max_age'];
 
 if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -455,7 +455,7 @@ $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
-$is_cached = is_array( $batcache->cache );
+$is_cached = is_array( $batcache->cache ) && isset( $batcache->cache['time'] );
 $has_expired = $is_cached && time() > $batcache->cache['time'] + $batcache->cache['max_age'];
 
 if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {
@@ -486,11 +486,11 @@ if ( $batcache->do )
 	$batcache->genlock = wp_cache_add("{$batcache->url_key}_genlock", 1, $batcache->group, 10);
 
 if (
-	isset( $batcache->cache['time'] ) && // We have cache
-	! $batcache->genlock &&            // We have not obtained cache regeneration lock
+	$is_cached && // We have cache
+	! $batcache->genlock &&  // We have not obtained cache regeneration lock
 	(
 		! $has_expired || // Batcached page that hasn't expired
-		( $batcache->do && $batcache->use_stale )                          // Regenerating it in another request and can use stale cache
+		( $batcache->do && $batcache->use_stale ) // Regenerating it in another request and can use stale cache
 	)
 ) {
 	// Issue redirect if cached and enabled

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -455,14 +455,15 @@ $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
-$has_expired = ! empty( $batcache->cache['time'] ) && time() > $batcache->cache['time'] + $batcache->cache['max_age'];
+$is_cached = ! empty( $batcache->cache );
+$has_expired = $is_cached && time() > $batcache->cache['time'] + $batcache->cache['max_age'];
 
 if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {
 	// Always refresh the cache if a newer version is available.
 	$batcache->do = true;
-} else if ( $has_expired && ( $batcache->seconds < 1 || $batcache->times < 2 ) ) {
-	// Cache has expired and we're caching all requests.
-	$batcache->do = true;
+} else if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
+	// Cache is empty or has expired and we're caching all requests.
+	$batcache->do = ! $is_cached || $has_expired;
 } else {
 	// No batcache item found, or ready to sample traffic again at the end of the batcache life?
 	if ( !is_array($batcache->cache) || time() >= $batcache->cache['time'] + $batcache->max_age - $batcache->seconds ) {

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -487,7 +487,7 @@ if ( $batcache->do )
 
 if (
 	$is_cached && // We have cache
-	! $batcache->genlock &&  // We have not obtained cache regeneration lock
+	! $batcache->genlock && // We have not obtained cache regeneration lock
 	(
 		! $has_expired || // Batcached page that hasn't expired
 		( $batcache->do && $batcache->use_stale ) // Regenerating it in another request and can use stale cache

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -455,7 +455,7 @@ $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
-$is_cached = ! is_array( $batcache->cache );
+$is_cached = is_array( $batcache->cache );
 $has_expired = $is_cached && time() > $batcache->cache['time'] + $batcache->cache['max_age'];
 
 if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {
@@ -466,7 +466,7 @@ if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $bat
 	$batcache->do = ! $is_cached || $has_expired;
 } else {
 	// No batcache item found, or ready to sample traffic again at the end of the batcache life?
-	if ( !is_array($batcache->cache) || time() >= $batcache->cache['time'] + $batcache->max_age - $batcache->seconds ) {
+	if ( ! $is_cached || time() >= $batcache->cache['time'] + $batcache->max_age - $batcache->seconds ) {
 		wp_cache_add($batcache->req_key, 0, $batcache->group);
 		$batcache->requests = wp_cache_incr($batcache->req_key, 1, $batcache->group);
 


### PR DESCRIPTION
When times < 2 or seconds < 1 it would always
recache the pages, even tho they should be served from
cache. Needed an expired check.

Testing Instructions:
1. Set times = 1, or seconds = 0
2. Visit any page that's cacheable
3. Check HTML comment, you'll see it's been `set`
4. Refresh page

Before:
5. The page isn't served from cache. It's set again.

After:
5. Served from cache