### PR TITLE
Allow batcache to ignore query args.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -72,7 +72,7 @@ class batcache {
 	var $cacheable_origin_hostnames = array(); // A whitelist of HTTP origin `<host>:<port>` (or just `<host>`) names that are allowed as cache variations.
 
 	var $origin = null; // Current Origin header.
-	var $query = '';
+	var $query = array();
 	var $ignored_query_args = array();
 	var $genlock = false;
 	var $do = false;
@@ -343,12 +343,8 @@ HTML;
 			unset( $this->query[ $arg ] );
 		}
 
-		if ( empty( $this->query ) ) {
-			$this->query = ''; // Because this is the default $query value.
-		} else {
-			// Normalize query parameters for better cache hits.
-			ksort( $this->query );
-		}
+		// Normalize query parameters for better cache hits.
+		ksort( $this->query );
 	}
 }
 

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -73,6 +73,7 @@ class batcache {
 
 	var $origin = null; // Current Origin header.
 	var $query = '';
+	var $ignored_query_args = array();
 	var $genlock = false;
 	var $do = false;
 
@@ -334,6 +335,21 @@ HTML;
 		}
 		$this->cache['output'] .= "\n$debug_html";
 	}
+
+	function set_query( $query_string ) {
+		parse_str( $query_string, $this->query );
+
+		foreach ( $this->ignored_query_args as $arg ) {
+			unset( $this->query[ $arg ] );
+		}
+
+		if ( empty( $this->query ) ) {
+			$this->query = ''; // Because this is the default $query value.
+		} else {
+			// Normalize query parameters for better cache hits.
+			ksort( $this->query );
+		}
+	}
 }
 
 global $batcache;
@@ -425,10 +441,7 @@ header('Vary: Cookie', false);
 
 // Things that define a unique page.
 if ( isset( $_SERVER['QUERY_STRING'] ) ) {
-	parse_str($_SERVER['QUERY_STRING'], $batcache->query);
-
-	// Normalize query paramaters for better cache hits.
-	ksort( $batcache->query );
+	$batcache->set_query( $_SERVER['QUERY_STRING'] );
 }
 
 $batcache->keys = array(


### PR DESCRIPTION
Makes it easier to ignore certain query args, if
they don't affect behavior. e.g. tracking query args.

Testing Instructions:
1. Apply patch
2. Add an ignored query arg, e.g. 'testing'
3. Visit a page
4. Make sure it's served from cache (check HTML comment)
5. Visit page with `testing=something` query param

Before:
6. The `testing=something` page would be cached with it's own key

After:
6. Same page from step 4. is served