### PR TITLE
fix array offset notices in PHP

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -485,9 +485,7 @@ if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $bat
 		wp_cache_add($batcache->req_key, 0, $batcache->group);
 		$batcache->requests = wp_cache_incr($batcache->req_key, 1, $batcache->group);
 
-		if ( $batcache->requests >= $batcache->times &&
-			time() >= $batcache->cache['time'] + $batcache->cache['max_age']
-		) {
+		if ( ( !is_array($batcache->cache) && $batcache->requests >= $batcache->times ) || ( is_array($batcache->cache) && $batcache->requests >= $batcache->times && time() >= $batcache->cache['time'] + $batcache->cache['max_age']	) ) {
 			wp_cache_delete( $batcache->req_key, $batcache->group );
 			$batcache->do = true;
 		} else {


### PR DESCRIPTION
When no batcache item is found, the array offset `$batcache->cache['time']` returns false. This throws array offset notices in PHP 7.4, filling logs. Adding an array check for when no batcache items exists to remove these PHP notices.