### PR TITLE
Cache redirects when max-age=0

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -1,0 +1,298 @@
+<?php
+
+// nananananananananananananananana BATCACHE!!!
+
+function batcache_cancel() {
+	global $batcache;
+
+	if ( is_object($batcache) )
+		$batcache->cancel = true;
+}
+
+class batcache {
+	// This is the base configuration. You can edit these variables or move them into your wp-config.php file.
+	var $max_age =  300; // Expire batcache items aged this many seconds (zero to disable batcache)
+	
+	var $remote  =    0; // Zero disables sending buffers to remote datacenters (req/sec is never sent)
+	
+	var $times   =    2; // Only batcache a page after it is accessed this many times... (two or more)
+	var $seconds =  120; // ...in this many seconds (zero to ignore this and use batcache immediately)
+	
+	var $group   = 'batcache'; // Name of memcached group. You can simulate a cache flush by changing this.
+	
+	var $unique  = array(); // If you conditionally serve different content, put the variable values here.
+	
+	var $headers = array(); // Add headers here. These will be sent with every response from the cache.
+
+	var $uncached_headers = array('transfer-encoding'); // These headers will never be cached. Apply strtolower.
+
+	var $debug   = true; // Set false to hide the batcache info <!-- comment -->
+
+	var $cache_control = true; // Set false to disable Last-Modified and Cache-Control headers
+
+	var $cancel = false; // Change this to cancel the output buffer. Use batcache_cancel();
+
+	function batcache( $settings ) {
+		if ( is_array( $settings ) ) foreach ( $settings as $k => $v )
+			$this->$k = $v;
+	}
+
+	function status_header( $status_header ) {
+		$this->status_header = $status_header;
+
+		return $status_header;
+	}
+
+	function configure_groups() {
+		// Configure the memcached client
+		if ( ! $this->remote )
+			if ( function_exists('wp_cache_add_no_remote_groups') )
+				wp_cache_add_no_remote_groups(array($this->group));
+		if ( function_exists('wp_cache_add_global_groups') )
+			wp_cache_add_global_groups(array($this->group));
+	}
+
+	// Defined here because timer_stop() calls number_format_i18n()
+	function timer_stop($display = 0, $precision = 3) {
+		global $timestart, $timeend;
+		$mtime = microtime();
+		$mtime = explode(' ',$mtime);
+		$mtime = $mtime[1] + $mtime[0];
+		$timeend = $mtime;
+		$timetotal = $timeend-$timestart;
+		$r = number_format($timetotal, $precision);
+		if ( $display )
+			echo $r;
+		return $r;
+	}
+
+	function ob($output) {
+		if ( $this->cancel !== false )
+			return $output;
+
+		// PHP5 and objects disappearing before output buffers?
+		wp_cache_init();
+
+		// Remember, $wp_object_cache was clobbered in wp-settings.php so we have to repeat this.
+		$this->configure_groups();
+
+		// Do not batcache blank pages (usually they are HTTP redirects)
+		$output = trim($output);
+		if ( empty($output) )
+			return;
+
+		// Construct and save the batcache
+		$cache = array(
+			'output' => $output,
+			'time' => time(),
+			'timer' => $this->timer_stop(false, 3),
+			'status_header' => $this->status_header,
+			'version' => $this->url_version
+		);
+
+		if ( function_exists( 'apache_response_headers' ) ) {
+			$cache['headers'] = apache_response_headers();
+			if ( !empty( $this->uncached_headers ) ) foreach ( $cache['headers'] as $header => $value ) {
+				if ( in_array( strtolower( $header ), $this->uncached_headers ) )
+					unset( $cache['headers'][$header] );
+			}
+		}
+
+		wp_cache_set($this->key, $cache, $this->group, $this->max_age + $this->seconds + 30);
+
+		// Unlock regeneration
+		wp_cache_delete("{$this->url_key}_genlock", $this->group);
+
+		if ( $this->cache_control ) {
+			header('Last-Modified: ' . date('r', $cache['time']), true);
+			header("Cache-Control: max-age=$this->max_age, must-revalidate", false);
+		}
+
+		if ( !empty($this->headers) ) foreach ( $this->headers as $k => $v ) {
+			if ( is_array( $v ) )
+				header("{$v[0]}: {$v[1]}", false);
+			else
+				header("$k: $v", true);
+		}
+
+		// Add some debug info just before </head>
+		if ( $this->debug ) {
+			$tag = "<!--\n\tgenerated in " . $cache['timer'] . " seconds\n\t" . strlen(serialize($cache)) . " bytes batcached for " . $this->max_age . " seconds\n-->\n";
+			if ( false !== $tag_position = strpos($output, '</head>') ) {
+				$tag = "<!--\n\tgenerated in " . $cache['timer'] . " seconds\n\t" . strlen(serialize($cache)) . " bytes batcached for " . $this->max_age . " seconds\n-->\n";
+				$output = substr($output, 0, $tag_position) . $tag . substr($output, $tag_position);
+			}
+		}
+
+		// Pass output to next ob handler
+		return $output;
+	}
+}
+global $batcache;
+// Pass in the global variable which may be an array of settings to override defaults.
+$batcache = new batcache($batcache);
+
+if ( ! defined( 'WP_CONTENT_DIR' ) )
+	return;
+
+// Never batcache interactive scripts or API endpoints.
+if ( in_array(
+		basename( $_SERVER['SCRIPT_FILENAME'] ),
+		array(
+			'wp-app.php',
+			'xmlrpc.php',
+		) ) )
+	return;
+
+// Never batcache WP javascript generators
+if ( strstr( $_SERVER['SCRIPT_FILENAME'], 'wp-includes/js' ) )
+	return;
+
+// Never batcache when POST data is present.
+if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) )
+	return;
+
+// Never batcache when cookies indicate a cache-exempt visitor.
+if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) )
+	foreach ( array_keys( $_COOKIE ) as $batcache->cookie )
+		if ( $batcache->cookie != 'wordpress_test_cookie' && ( substr( $batcache->cookie, 0, 2 ) == 'wp' || substr( $batcache->cookie, 0, 9 ) == 'wordpress' || substr( $batcache->cookie, 0, 14 ) == 'comment_author' ) )
+			return;
+
+if ( ! include_once( WP_CONTENT_DIR . '/object-cache.php' ) )
+	return;
+
+wp_cache_init(); // Note: wp-settings.php calls wp_cache_init() which clobbers the object made here.
+
+if ( ! is_object( $wp_object_cache ) )
+	return;
+
+// Now that the defaults are set, you might want to use different settings under certain conditions.
+
+/* Example: if your documents have a mobile variant (a different document served by the same URL) you must tell batcache about the variance. Otherwise you might accidentally cache the mobile version and serve it to desktop users, or vice versa.
+$batcache->unique['mobile'] = is_mobile_user_agent();
+*/
+
+/* Example: never batcache for this host
+if ( $_SERVER['HTTP_HOST'] == 'do-not-batcache-me.com' )
+	return;
+*/
+
+/* Example: batcache everything on this host regardless of traffic level
+if ( $_SERVER['HTTP_HOST'] == 'always-batcache-me.com' )
+	return;
+*/
+
+/* Example: If you sometimes serve variants dynamically (e.g. referrer search term highlighting) you probably don't want to batcache those variants. Remember this code is run very early in wp-settings.php so plugins are not yet loaded. You will get a fatal error if you try to call an undefined function. Either include your plugin now or define a test function in this file.
+if ( include_once( 'plugins/searchterm-highlighter.php') && referrer_has_search_terms() )
+	return;
+*/
+
+// Disabled
+if ( $batcache->max_age < 1 )
+	return;
+
+// Make sure we can increment. If not, turn off the traffic sensor.
+if ( ! method_exists( $GLOBALS['wp_object_cache'], 'incr' ) )
+	$batcache->times = 0;
+
+// Necessary to prevent clients using cached version after login cookies set. If this is a problem, comment it out and remove all Last-Modified headers.
+header('Vary: Cookie', false);
+
+// Things that define a unique page.
+if ( isset( $_SERVER['QUERY_STRING'] ) )
+	parse_str($_SERVER['QUERY_STRING'], $batcache->query);
+$batcache->keys = array(
+	'host' => $_SERVER['HTTP_HOST'],
+	'path' => ( $batcache->pos = strpos($_SERVER['REQUEST_URI'], '?') ) ? substr($_SERVER['REQUEST_URI'], 0, $batcache->pos) : $_SERVER['REQUEST_URI'],
+	'query' => $batcache->query,
+	'extra' => $batcache->unique
+);
+
+$batcache->configure_groups();
+
+// Generate the batcache key
+$batcache->key = md5(serialize($batcache->keys));
+
+// Generate the traffic threshold measurement key
+$batcache->req_key = $batcache->key . '_req';
+
+// Get the batcache
+$batcache->cache = wp_cache_get($batcache->key, $batcache->group);
+
+// Are we only caching frequently-requested pages?
+if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
+	$batcache->do = true;
+} else {
+	// No batcache item found, or ready to sample traffic again at the end of the batcache life?
+	if ( !is_array($batcache->cache) || time() >= $batcache->cache['time'] + $batcache->max_age - $batcache->seconds ) {
+		wp_cache_add($batcache->req_key, 0, $batcache->group);
+		$batcache->requests = wp_cache_incr($batcache->req_key, 1, $batcache->group);
+
+		if ( $batcache->requests >= $batcache->times )
+			$batcache->do = true;
+		else
+			$batcache->do = false;
+	}
+}
+
+// Recreate the permalink from the URL
+$batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
+$batcache->url_key = md5($batcache->permalink);
+$batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
+
+// If the document has been updated and we are the first to notice, regenerate it.
+if ( $batcache->do !== false && isset($batcache->cache['version']) && $batcache->cache['version'] < $batcache->url_version )
+	$batcache->genlock = wp_cache_add("{$batcache->url_key}_genlock", 1, $batcache->group);
+
+// Did we find a batcached page that hasn't expired?
+if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcache->cache['time'] + $batcache->max_age ) {
+	// Issue "304 Not Modified" only if the dates match exactly.
+	if ( $batcache->cache_control && isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ) {
+		$since = strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']);
+		if ( $batcache->cache['time'] == $since ) {
+			header('Last-Modified: ' . $_SERVER['HTTP_IF_MODIFIED_SINCE'], true, 304);
+			exit;
+		}
+	}
+
+	// Use the batcache save time for Last-Modified so we can issue "304 Not Modified"
+	if ( $batcache->cache_control ) {
+		header('Last-Modified: ' . date('r', $batcache->cache['time']), true);
+		header('Cache-Control: max-age=' . ($batcache->max_age - time() + $batcache->cache['time']) . ', must-revalidate', true);
+	}
+
+	// Add some debug info just before </head>
+	if ( $batcache->debug ) {
+		if ( false !== $tag_position = strpos($batcache->cache['output'], '</head>') ) {
+			$tag = "<!--\n\tgenerated " . (time() - $batcache->cache['time']) . " seconds ago\n\tgenerated in " . $batcache->cache['timer'] . " seconds\n\tserved from batcache in " . $batcache->timer_stop(false, 3) . " seconds\n\texpires in " . ($batcache->max_age - time() + $batcache->cache['time']) . " seconds\n-->\n";
+			$batcache->cache['output'] = substr($batcache->cache['output'], 0, $tag_position) . $tag . substr($batcache->cache['output'], $tag_position);
+		}
+	}
+
+	if ( !empty($batcache->cache['headers']) ) foreach ( $batcache->cache['headers'] as $k => $v )
+		header("$k: $v", true);
+
+	if ( !empty($batcache->headers) ) foreach ( $batcache->headers as $k => $v ) {
+		if ( is_array( $v ) )
+			header("{$v[0]}: {$v[1]}", false);
+		else
+			header("$k: $v", true);
+	}
+
+	if ( !empty($batcache->cache['status_header']) )
+		header($batcache->cache['status_header'], true);
+
+	// Have you ever heard a death rattle before?
+	die($batcache->cache['output']);
+}
+
+// Didn't meet the minimum condition?
+if ( !$batcache->do && !$batcache->genlock )
+	return;
+
+$wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 1 );
+
+ob_start(array(&$batcache, 'ob'));
+
+// It is safer to omit the final PHP closing tag.
+

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -63,7 +63,7 @@ class batcache {
 
 	var $debug   = true; // Set false to hide the batcache info <!-- comment -->
 
-	var $cache_control = false; // Set false to disable Last-Modified and Cache-Control headers
+	var $cache_control = true; // Set false to disable Last-Modified and Cache-Control headers
 
 	var $cancel = false; // Change this to cancel the output buffer. Use batcache_cancel();
 

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -63,7 +63,7 @@ class batcache {
 
 	var $debug   = true; // Set false to hide the batcache info <!-- comment -->
 
-	var $cache_control = true; // Set false to disable Last-Modified and Cache-Control headers
+	var $cache_control = false; // Set false to disable Last-Modified and Cache-Control headers
 
 	var $cancel = false; // Change this to cancel the output buffer. Use batcache_cancel();
 

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -456,7 +456,7 @@ if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) ) {
 	}
 }
 
-if ( ! include_once( WP_CONTENT_DIR . '/object-cache.php' ) ) {
+if ( ! function_exists( 'wp_cache_init' )  && ! include_once( WP_CONTENT_DIR . '/object-cache.php' ) ) {
 
 	if ( $batcache->add_hit_status_header ) {
 		header( 'X-Batcache: DOWN' );

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -675,8 +675,14 @@ if ( ! $batcache->do || ! $batcache->genlock )
 	return;
 
 global $wp_filter;
-$wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 2 );
-$wp_filter['wp_redirect_status'][10]['batcache'] = array( 'function' => array(&$batcache, 'redirect_status'), 'accepted_args' => 2 );
+if ( function_exists( 'add_filter' ) ) {
+	add_filter( 'status_header', array( $batcache, 'status_header' ), 10, 2 );
+	add_filter( 'wp_redirect_status', array( $batcache, 'redirect_status' ), 10, 2 );
+} else {
+	$wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 2 );
+	$wp_filter['wp_redirect_status'][10]['batcache'] = array( 'function' => array(&$batcache, 'redirect_status'), 'accepted_args' => 2 );
+}
+
 
 ob_start(array(&$batcache, 'ob'));
 

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -1,4 +1,10 @@
 <?php
+if ( is_readable( dirname( __FILE__ ) . '/batcache-stats.php' ) )
+	require_once dirname( __FILE__ ) . '/batcache-stats.php';
+
+if ( !function_exists( 'batcache_stats' ) ) {
+	function batcache_stats( $name, $value, $num = 1, $today = FALSE, $hour = FALSE ) { }
+}
 
 // nananananananananananananananana BATCACHE!!!
 
@@ -9,20 +15,49 @@ function batcache_cancel() {
 		$batcache->cancel = true;
 }
 
+// Variants can be set by functions which use early-set globals like $_SERVER to run simple tests.
+// Functions defined in WordPress, plugins, and themes are not available and MUST NOT be used.
+// Example: vary_cache_on_function('return preg_match("/feedburner/i", $_SERVER["HTTP_USER_AGENT"]);');
+//          This will cause batcache to cache a variant for requests from Feedburner.
+// Tips for writing $function:
+//  X_X  DO NOT use any functions from your theme or plugins. Those files have not been included. Fatal error.
+//  X_X  DO NOT use any WordPress functions except is_admin() and is_multisite(). Fatal error.
+//  X_X  DO NOT include or require files from anywhere without consulting expensive professionals first. Fatal error.
+//  X_X  DO NOT use $wpdb, $blog_id, $current_user, etc. These have not been initialized.
+//  ^_^  DO understand how create_function works. This is how your code is used: create_function('', $function);
+//  ^_^  DO remember to return something. The return value determines the cache variant.
+function vary_cache_on_function($function) {
+	global $batcache;
+
+	if ( preg_match('/include|require|echo|print|dump|export|open|sock|unlink|`|eval/i', $function) )
+		die('Illegal word in variant determiner.');
+
+	if ( !preg_match('/\$_/', $function) )
+		die('Variant determiner should refer to at least one $_ variable.');
+
+	$batcache->add_variant($function);
+}
+
 class batcache {
 	// This is the base configuration. You can edit these variables or move them into your wp-config.php file.
 	var $max_age =  300; // Expire batcache items aged this many seconds (zero to disable batcache)
-	
+
 	var $remote  =    0; // Zero disables sending buffers to remote datacenters (req/sec is never sent)
-	
+
 	var $times   =    2; // Only batcache a page after it is accessed this many times... (two or more)
 	var $seconds =  120; // ...in this many seconds (zero to ignore this and use batcache immediately)
-	
+
 	var $group   = 'batcache'; // Name of memcached group. You can simulate a cache flush by changing this.
-	
+
 	var $unique  = array(); // If you conditionally serve different content, put the variable values here.
-	
-	var $headers = array(); // Add headers here. These will be sent with every response from the cache.
+
+	var $vary    = array(); // Array of functions for create_function. The return value is added to $unique above.
+
+	var $headers = array(); // Add headers here as name=>value or name=>array(values). These will be sent with every response from the cache.
+
+	var $cache_redirects = false; // Set true to enable redirect caching.
+	var $redirect_status = false; // This is set to the response code during a redirect.
+	var $redirect_location = false; // This is set to the redirect location.
 
 	var $uncached_headers = array('transfer-encoding'); // These headers will never be cached. Apply strtolower.
 
@@ -32,17 +67,63 @@ class batcache {
 
 	var $cancel = false; // Change this to cancel the output buffer. Use batcache_cancel();
 
-	var $do = false; // By default, we do not cache
+	var $noskip_cookies = array( 'wordpress_test_cookie' ); // Names of cookies - if they exist and the cache would normally be bypassed, don't bypass it
 
 	function batcache( $settings ) {
 		if ( is_array( $settings ) ) foreach ( $settings as $k => $v )
 			$this->$k = $v;
 	}
 
-	function status_header( $status_header ) {
+	function is_ssl() {
+		if ( isset($_SERVER['HTTPS']) ) {
+			if ( 'on' == strtolower($_SERVER['HTTPS']) )
+				return true;
+			if ( '1' == $_SERVER['HTTPS'] )
+				return true;
+		} elseif ( isset($_SERVER['SERVER_PORT']) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	function status_header( $status_header, $status_code ) {
 		$this->status_header = $status_header;
+		$this->status_code = $status_code;
 
 		return $status_header;
+	}
+
+	function redirect_status( $status, $location ) {
+		if ( $this->cache_redirects ) {
+			$this->redirect_status = $status;
+			$this->redirect_location = $location;
+		}
+
+		return $status;
+	}
+
+	function do_headers( $headers1, $headers2 = array() ) {
+		// Merge the arrays of headers into one
+		$headers = array();
+		$keys = array_unique( array_merge( array_keys( $headers1 ), array_keys( $headers2 ) ) );
+		foreach ( $keys as $k ) {
+			$headers[$k] = array();
+			if ( isset( $headers1[$k] ) && isset( $headers2[$k] ) )
+				$headers[$k] = array_merge( (array) $headers2[$k], (array) $headers1[$k] );
+			elseif ( isset( $headers2[$k] ) )
+				$headers[$k] = (array) $headers2[$k];
+			else
+				$headers[$k] = (array) $headers1[$k];
+			$headers[$k] = array_unique( $headers[$k] );
+		}
+		// These headers take precedence over any previously sent with the same names
+		foreach ( $headers as $k => $values ) {
+			$clobber = true;
+			foreach ( $values as $v ) {
+				header( "$k: $v", $clobber );
+				$clobber = false;
+			}
+		}
 	}
 
 	function configure_groups() {
@@ -78,58 +159,150 @@ class batcache {
 		// Remember, $wp_object_cache was clobbered in wp-settings.php so we have to repeat this.
 		$this->configure_groups();
 
-		// Do not batcache blank pages (usually they are HTTP redirects)
+		// Do not batcache blank pages unless they are HTTP redirects
 		$output = trim($output);
-		if ( empty($output) )
+		if ( $output === '' && (!$this->redirect_status || !$this->redirect_location) )
 			return;
 
+		// Do not cache 5xx responses
+		if ( isset( $this->status_code ) && intval($this->status_code / 100) == 5 )
+			return $output;
+
+		$this->do_variants($this->vary);
+		$this->generate_keys();
+
 		// Construct and save the batcache
-		$cache = array(
+		$this->cache = array(
 			'output' => $output,
 			'time' => time(),
 			'timer' => $this->timer_stop(false, 3),
+			'headers' => array(),
 			'status_header' => $this->status_header,
+			'redirect_status' => $this->redirect_status,
+			'redirect_location' => $this->redirect_location,
 			'version' => $this->url_version
 		);
 
-		if ( function_exists( 'apache_response_headers' ) ) {
-			$cache['headers'] = apache_response_headers();
-			if ( !empty( $this->uncached_headers ) ) foreach ( $cache['headers'] as $header => $value ) {
-				if ( in_array( strtolower( $header ), $this->uncached_headers ) )
-					unset( $cache['headers'][$header] );
-			}
+		foreach ( headers_list() as $header ) {
+			list($k, $v) = array_map('trim', explode(':', $header, 2));
+			$this->cache['headers'][$k][] = $v;
 		}
 
-		wp_cache_set($this->key, $cache, $this->group, $this->max_age + $this->seconds + 30);
+		if ( !empty( $this->cache['headers'] ) && !empty( $this->uncached_headers ) ) {
+			foreach ( $this->uncached_headers as $header )
+				unset( $this->cache['headers'][$header] );
+		}
+
+		foreach ( $this->cache['headers'] as $header => $values ) {
+			// Do not cache if cookies were set
+			if ( strtolower( $header ) === 'set-cookie' )
+				return $output;
+
+			foreach ( (array) $values as $value )
+				if ( preg_match('/^Cache-Control:.*max-?age=(\d+)/i', "$header: $value", $matches) )
+					$this->max_age = intval($matches[1]);
+		}
+
+		$this->cache['max_age'] = $this->max_age;
+
+		wp_cache_set($this->key, $this->cache, $this->group, $this->max_age + $this->seconds + 30);
 
 		// Unlock regeneration
 		wp_cache_delete("{$this->url_key}_genlock", $this->group);
 
 		if ( $this->cache_control ) {
-			header('Last-Modified: ' . date('r', $cache['time']), true);
-			header("Cache-Control: max-age=$this->max_age, must-revalidate", false);
+			// Don't clobber Last-Modified header if already set, e.g. by WP::send_headers()
+			if ( !isset($this->cache['headers']['Last-Modified']) )
+				header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $this->cache['time'] ) . ' GMT', true );
+			if ( !isset($this->cache['headers']['Cache-Control']) )
+				header("Cache-Control: max-age=$this->max_age, must-revalidate", false);
 		}
 
-		if ( !empty($this->headers) ) foreach ( $this->headers as $k => $v ) {
-			if ( is_array( $v ) )
-				header("{$v[0]}: {$v[1]}", false);
-			else
-				header("$k: $v", true);
-		}
+		$this->do_headers( $this->headers );
 
-		// Add some debug info just before </head>
+		// Add some debug info just before <head
 		if ( $this->debug ) {
-			$tag = "<!--\n\tgenerated in " . $cache['timer'] . " seconds\n\t" . strlen(serialize($cache)) . " bytes batcached for " . $this->max_age . " seconds\n-->\n";
-			if ( false !== $tag_position = strpos($output, '</head>') ) {
-				$tag = "<!--\n\tgenerated in " . $cache['timer'] . " seconds\n\t" . strlen(serialize($cache)) . " bytes batcached for " . $this->max_age . " seconds\n-->\n";
-				$output = substr($output, 0, $tag_position) . $tag . substr($output, $tag_position);
-			}
+			$this->add_debug_just_cached();
 		}
 
 		// Pass output to next ob handler
-		return $output;
+		batcache_stats( 'batcache', 'total_page_views' );
+		return $this->cache['output'];
+	}
+
+	function add_variant($function) {
+		$key = md5($function);
+		$this->vary[$key] = $function;
+	}
+
+	function do_variants($dimensions = false) {
+		// This function is called without arguments early in the page load, then with arguments during the OB handler.
+		if ( $dimensions === false )
+			$dimensions = wp_cache_get("{$this->url_key}_vary", $this->group);
+		else
+			wp_cache_set("{$this->url_key}_vary", $dimensions, $this->group, $this->max_age + 10);
+
+		if ( is_array($dimensions) ) {
+			ksort($dimensions);
+			foreach ( $dimensions as $key => $function ) {
+				$fun = create_function('', $function);
+				$value = $fun();
+				$this->keys[$key] = $value;
+			}
+		}
+	}
+
+	function generate_keys() {
+		// ksort($this->keys); // uncomment this when traffic is slow
+		$this->key = md5(serialize($this->keys));
+		$this->req_key = $this->key . '_req';
+	}
+
+	function add_debug_just_cached() {
+		$generation = $this->cache['timer'];
+		$bytes = strlen( serialize( $this->cache ) );
+		$html = <<<HTML
+<!--
+	generated in $generation seconds
+	$bytes bytes batcached for {$this->max_age} seconds
+-->
+
+HTML;
+		$this->add_debug_html_to_output( $html );
+	}
+
+	function add_debug_from_cache() {
+		$seconds_ago = time() - $this->cache['time'];
+		$generation = $this->cache['timer'];
+		$serving = $this->timer_stop( false, 3 );
+		$expires = $this->cache['max_age'] - time() + $this->cache['time'];
+		$html = <<<HTML
+<!--
+	generated $seconds_ago seconds ago
+	generated in $generation seconds
+	served from batcache in $serving seconds
+	expires in $expires seconds
+-->
+
+HTML;
+		$this->add_debug_html_to_output( $html );
+	}
+
+	function add_debug_html_to_output( $debug_html ) {
+		// Casing on the Content-Type header is inconsistent
+		foreach ( array( 'Content-Type', 'Content-type' ) as $key ) {
+			if ( isset( $this->cache['headers'][ $key ][0] ) && 0 !== strpos( $this->cache['headers'][ $key ][0], 'text/html' ) )
+				return;
+		}
+
+		$head_position = strpos( $this->cache['output'], '<head' );
+		if ( false === $head_position ) {
+			return;
+		}
+		$this->cache['output'] = substr_replace( $this->cache['output'], $debug_html, $head_position, 0 );
 	}
 }
+
 global $batcache;
 // Pass in the global variable which may be an array of settings to override defaults.
 $batcache = new batcache($batcache);
@@ -143,7 +316,6 @@ if ( in_array(
 		array(
 			'wp-app.php',
 			'xmlrpc.php',
-			'ms-files.php',
 		) ) )
 	return;
 
@@ -156,10 +328,14 @@ if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) )
 	return;
 
 // Never batcache when cookies indicate a cache-exempt visitor.
-if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) )
-	foreach ( array_keys( $_COOKIE ) as $batcache->cookie )
-		if ( $batcache->cookie != 'wordpress_test_cookie' && ( substr( $batcache->cookie, 0, 2 ) == 'wp' || substr( $batcache->cookie, 0, 9 ) == 'wordpress' || substr( $batcache->cookie, 0, 14 ) == 'comment_author' ) )
+if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) ) {
+	foreach ( array_keys( $_COOKIE ) as $batcache->cookie ) {
+		if ( ! in_array( $batcache->cookie, $batcache->noskip_cookies ) && ( substr( $batcache->cookie, 0, 2 ) == 'wp' || substr( $batcache->cookie, 0, 9 ) == 'wordpress' || substr( $batcache->cookie, 0, 14 ) == 'comment_author' ) ) {
+			batcache_stats( 'batcache', 'cookie_skip' );
 			return;
+		}
+	}
+}
 
 if ( ! include_once( WP_CONTENT_DIR . '/object-cache.php' ) )
 	return;
@@ -204,20 +380,25 @@ header('Vary: Cookie', false);
 // Things that define a unique page.
 if ( isset( $_SERVER['QUERY_STRING'] ) )
 	parse_str($_SERVER['QUERY_STRING'], $batcache->query);
+
 $batcache->keys = array(
 	'host' => $_SERVER['HTTP_HOST'],
+	'method' => $_SERVER['REQUEST_METHOD'],
 	'path' => ( $batcache->pos = strpos($_SERVER['REQUEST_URI'], '?') ) ? substr($_SERVER['REQUEST_URI'], 0, $batcache->pos) : $_SERVER['REQUEST_URI'],
 	'query' => $batcache->query,
 	'extra' => $batcache->unique
 );
 
+if ( $batcache->is_ssl() )
+	$batcache->keys['ssl'] = true;
+
+// Recreate the permalink from the URL
+$batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
+$batcache->url_key = md5($batcache->permalink);
+$batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
 $batcache->configure_groups();
-
-// Generate the batcache key
-$batcache->key = md5(serialize($batcache->keys));
-
-// Generate the traffic threshold measurement key
-$batcache->req_key = $batcache->key . '_req';
+$batcache->do_variants();
+$batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
@@ -238,49 +419,84 @@ if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
 	}
 }
 
-// Recreate the permalink from the URL
-$batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
-$batcache->url_key = md5($batcache->permalink);
-$batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
-
 // If the document has been updated and we are the first to notice, regenerate it.
 if ( $batcache->do !== false && isset($batcache->cache['version']) && $batcache->cache['version'] < $batcache->url_version )
-	$batcache->genlock = wp_cache_add("{$batcache->url_key}_genlock", 1, $batcache->group);
-else $batcache->genlock = 0;
+	$batcache->genlock = wp_cache_add("{$batcache->url_key}_genlock", 1, $batcache->group, 10);
+
+// Temporary: remove after 2010-11-12. I added max_age to the cache. This upgrades older caches on the fly.
+if ( !isset($batcache->cache['max_age']) )
+	$batcache->cache['max_age'] = $batcache->max_age;
+
 
 // Did we find a batcached page that hasn't expired?
-if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcache->cache['time'] + $batcache->max_age ) {
-	// Issue "304 Not Modified" only if the dates match exactly.
-	if ( $batcache->cache_control && isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ) {
-		$since = strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']);
-		if ( $batcache->cache['time'] == $since ) {
-			header('Last-Modified: ' . $_SERVER['HTTP_IF_MODIFIED_SINCE'], true, 304);
-			exit;
+if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcache->cache['time'] + $batcache->cache['max_age'] ) {
+	// Issue redirect if cached and enabled
+	if ( $batcache->cache['redirect_status'] && $batcache->cache['redirect_location'] && $batcache->cache_redirects ) {
+		$status = $batcache->cache['redirect_status'];
+		$location = $batcache->cache['redirect_location'];
+		// From vars.php
+		$is_IIS = (strpos($_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== false || strpos($_SERVER['SERVER_SOFTWARE'], 'ExpressionDevServer') !== false);
+
+		$batcache->do_headers( $batcache->headers );
+		if ( $is_IIS ) {
+			header("Refresh: 0;url=$location");
+		} else {
+			if ( php_sapi_name() != 'cgi-fcgi' ) {
+				$texts = array(
+					300 => 'Multiple Choices',
+					301 => 'Moved Permanently',
+					302 => 'Found',
+					303 => 'See Other',
+					304 => 'Not Modified',
+					305 => 'Use Proxy',
+					306 => 'Reserved',
+					307 => 'Temporary Redirect',
+				);
+				$protocol = $_SERVER["SERVER_PROTOCOL"];
+				if ( 'HTTP/1.1' != $protocol && 'HTTP/1.0' != $protocol )
+					$protocol = 'HTTP/1.0';
+				if ( isset($texts[$status]) )
+					header("$protocol $status " . $texts[$status]);
+				else
+					header("$protocol 302 Found");
+			}
+			header("Location: $location");
 		}
+		exit;
 	}
 
-	// Use the batcache save time for Last-Modified so we can issue "304 Not Modified"
-	if ( $batcache->cache_control ) {
-		header('Last-Modified: ' . date('r', $batcache->cache['time']), true);
-		header('Cache-Control: max-age=' . ($batcache->max_age - time() + $batcache->cache['time']) . ', must-revalidate', true);
+	// Respect ETags served with feeds.
+	if ( isset( $SERVER['HTTP_IF_NONE_MATCH'] ) && isset( $batcache->cache['headers']['ETag'][0] ) && $_SERVER['HTTP_IF_NONE_MATCH'] == $batcache->cache['headers']['ETag'][0] )
+		$three04 = true;
+
+	// Respect If-Modified-Since.
+	elseif ( $batcache->cache_control && isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ) {
+		$client_time = strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']);
+		if ( isset($batcache->cache['headers']['Last-Modified'][0]) )
+			$cache_time = strtotime($batcache->cache['headers']['Last-Modified'][0]);
+		else
+			$cache_time = $batcache->cache['time'];
+
+		if ( $client_time >= $cache_time )
+			$three04 = true;
+	}
+
+	// Use the batcache save time for Last-Modified so we can issue "304 Not Modified" but don't clobber a cached Last-Modified header.
+	if ( $batcache->cache_control && !isset($batcache->cache['headers']['Last-Modified'][0]) ) {
+		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $batcache->cache['time'] ) . ' GMT', true );
+		header('Cache-Control: max-age=' . ($batcache->cache['max_age'] - time() + $batcache->cache['time']) . ', must-revalidate', true);
 	}
 
 	// Add some debug info just before </head>
 	if ( $batcache->debug ) {
-		if ( false !== $tag_position = strpos($batcache->cache['output'], '</head>') ) {
-			$tag = "<!--\n\tgenerated " . (time() - $batcache->cache['time']) . " seconds ago\n\tgenerated in " . $batcache->cache['timer'] . " seconds\n\tserved from batcache in " . $batcache->timer_stop(false, 3) . " seconds\n\texpires in " . ($batcache->max_age - time() + $batcache->cache['time']) . " seconds\n-->\n";
-			$batcache->cache['output'] = substr($batcache->cache['output'], 0, $tag_position) . $tag . substr($batcache->cache['output'], $tag_position);
-		}
+		$batcache->add_debug_from_cache();
 	}
 
-	if ( !empty($batcache->cache['headers']) ) foreach ( $batcache->cache['headers'] as $k => $v )
-		header("$k: $v", true);
+	$batcache->do_headers( $batcache->headers, $batcache->cache['headers'] );
 
-	if ( !empty($batcache->headers) ) foreach ( $batcache->headers as $k => $v ) {
-		if ( is_array( $v ) )
-			header("{$v[0]}: {$v[1]}", false);
-		else
-			header("$k: $v", true);
+	if ( $three04 ) {
+		header("HTTP/1.1 304 Not Modified", true, 304);
+		die;
 	}
 
 	if ( !empty($batcache->cache['status_header']) )
@@ -294,7 +510,8 @@ if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcac
 if ( !$batcache->do && !$batcache->genlock )
 	return;
 
-$wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 1 );
+$wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 2 );
+$wp_filter['wp_redirect_status'][10]['batcache'] = array( 'function' => array(&$batcache, 'redirect_status'), 'accepted_args' => 2 );
 
 ob_start(array(&$batcache, 'ob'));
 

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -69,6 +69,8 @@ class batcache {
 
 	var $noskip_cookies = array( 'wordpress_test_cookie' ); // Names of cookies - if they exist and the cache would normally be bypassed, don't bypass it
 
+	var $add_hit_status_header = true; // Add X-Batache HTTP header for "HIT" "BYPASS" "MISS" etc
+
 	var $genlock = false;
 	var $do = false;
 
@@ -465,6 +467,10 @@ if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcac
 			}
 			header("Location: $location");
 		}
+
+		if ( $batcache->add_hit_status_header ) {
+			header( 'X-Batcache: HIT' );
+		}
 		exit;
 	}
 
@@ -500,11 +506,20 @@ if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcac
 
 	if ( $three04 ) {
 		header("HTTP/1.1 304 Not Modified", true, 304);
+
+		if ( $batcache->add_hit_status_header ) {
+			header( 'X-Batcache: HIT' );
+		}
+
 		die;
 	}
 
 	if ( !empty($batcache->cache['status_header']) )
 		header($batcache->cache['status_header'], true);
+
+	if ( $batcache->add_hit_status_header ) {
+		header( 'X-Batcache: HIT' );
+	}
 
 	// Have you ever heard a death rattle before?
 	die($batcache->cache['output']);
@@ -513,6 +528,10 @@ if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcac
 // Didn't meet the minimum condition?
 if ( !$batcache->do && !$batcache->genlock )
 	return;
+
+if ( $batcache->add_hit_status_header ) {
+	header( 'X-Batcache: MISS' );
+}
 
 $wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 2 );
 $wp_filter['wp_redirect_status'][10]['batcache'] = array( 'function' => array(&$batcache, 'redirect_status'), 'accepted_args' => 2 );

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -672,6 +672,7 @@ if ( isset( $batcache->cache['time'] ) && // We have cache
 if ( ! $batcache->do || ! $batcache->genlock )
 	return;
 
+global $wp_filter;
 $wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 2 );
 $wp_filter['wp_redirect_status'][10]['batcache'] = array( 'function' => array(&$batcache, 'redirect_status'), 'accepted_args' => 2 );
 

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -377,6 +377,17 @@ if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) || $_SERVER[
 	return;
 }
 
+// Never cache Basic Auth'ed requests.
+if ( ! empty( $_SERVER['PHP_AUTH_USER'] ) ) {
+
+	if ( $batcache->add_hit_status_header ) {
+		header( 'X-Batcache: BYPASS' );
+		header( 'X-Batcache-Reason: Basic Auth Request' );
+	}
+
+	return;
+}
+
 // Never batcache when cookies indicate a cache-exempt visitor.
 if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) ) {
 	foreach ( array_keys( $_COOKIE ) as $batcache->cookie ) {

--- a/batcache-stats-example.php
+++ b/batcache-stats-example.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This is a copy of our Batcache-stats.php file but it is suffixed so that you don't use it by default.
+ * You probably don't want huge log files filling up your server by default, but this gives you and idea
+ * of how we use this function. We have a separate parsing script that comes along and reads these files
+ * and enters them into our internal stats.
+ */
+
+if ( !function_exists( 'batcache_stats' ) ) {
+	function batcache_stats( $name, $value, $num = 1, $today = FALSE, $hour = FALSE ) {
+		if ( !$today )
+			$today = gmdate( 'Y-m-d' );
+		if ( !$hour )
+			$hour = gmdate( 'Y-m-d H:00:00' );
+
+		// batcache never loads wpdb so always do this async
+		if ( !file_exists( '/var/spool/wpcom/extra' ) )
+			mkdir( '/var/spool/wpcom/extra', 0777 );
+
+		$value = rawurlencode( $value );
+		$stats_filename = "/var/spool/wpcom/extra/{$today}_" . gmdate( 'H' . '-' . 'i' );
+		if ( ! file_exists( $stats_filename ) ) {
+			touch( $stats_filename );
+			chmod( $stats_filename, 0777 );
+		}
+
+		$fp = fopen( $stats_filename,  'a' );
+		fwrite( $fp, "{$hour}\t{$name}\t{$value}\t{$num}" . chr( 10 ) );
+		fclose( $fp );
+	}
+}

--- a/batcache.php
+++ b/batcache.php
@@ -1,0 +1,45 @@
+<?php
+/*
+Plugin name: Batcache Manager
+Plugin URI: http://wordpress.org/extend/plugins/batcache/
+Description: This optional plugin improves Batcache.
+Author: Andy Skelton
+Author URI: http://andyskelton.com/
+Version: 1.0
+*/
+
+// Do not load if our advanced-cache.php isn't loaded
+if ( ! is_object($batcache) || ! method_exists( $wp_object_cache, 'incr' ) )
+	return;
+
+$batcache->configure_groups();
+
+// Regen home and permalink on posts and pages
+add_action('clean_post_cache', 'batcache_post');
+
+// Regen permalink on comments (TODO)
+//add_action('comment_post',          'batcache_comment');
+//add_action('wp_set_comment_status', 'batcache_comment');
+//add_action('edit_comment',          'batcache_comment');
+
+function batcache_post($post_id) {
+	global $batcache;
+
+	$post = get_post($post_id);
+	if ( $post->post_type == 'revision' || get_post_status($post_id) != 'publish' )
+		return;
+
+	batcache_clear_url( get_option('home') );
+	batcache_clear_url( trailingslashit( get_option('home') ) );
+	batcache_clear_url( get_permalink($post_id) );
+}
+
+function batcache_clear_url($url) {
+	global $batcache;
+	if ( empty($url) )
+		return false;
+	$url_key = md5($url);
+	wp_cache_add("{$url_key}_version", 0, $batcache->group);
+	return wp_cache_incr("{$url_key}_version", 1, $batcache->group);
+}
+

--- a/batcache.php
+++ b/batcache.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/batcache/
 Description: This optional plugin improves Batcache.
 Author: Andy Skelton
 Author URI: http://andyskelton.com/
-Version: 1.2
+Version: 1.3.1
 */
 
 // Do not load if our advanced-cache.php isn't loaded

--- a/batcache.php
+++ b/batcache.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/batcache/
 Description: This optional plugin improves Batcache.
 Author: Andy Skelton
 Author URI: http://andyskelton.com/
-Version: 1.0
+Version: 1.2
 */
 
 // Do not load if our advanced-cache.php isn't loaded

--- a/batcache.php
+++ b/batcache.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/batcache/
 Description: This optional plugin improves Batcache.
 Author: Andy Skelton
 Author URI: http://andyskelton.com/
-Version: 1.3.1
+Version: 1.3.4
 */
 
 // Do not load if our advanced-cache.php isn't loaded

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, andy, orensol, markjaquith, vnsavage, batmoo, yoavf
 Tags: cache, memcache, memcached, speed, performance, load, server
 Requires at least: 3.2
 Tested up to: 3.5
-Stable tag: 1.3
+Stable tag: 1.3.1
 
 Batcache uses Memcached to store and serve rendered pages.
 
@@ -63,7 +63,10 @@ Batcache was named "supercache" when it was written. (It's still called that on 
 == Changelog ==
 
 = trunk =
+
+= 1.3.1 =
 * Add REQUEST_METHOD to the cache keys. Prevents GET requests receiving bodyless HEAD responses. This change invalidates the entire cache at upgrade time.
+* Add ORIGIN into the cache keys to create cache variation for different origin requests. 
 
 = 1.1 =
 * Many bugfixes and updates from trunk

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,62 @@
+=== Batcache ===
+Contributors: andy
+Tags: cache, memcached, speed, performance, digg
+Requires at least: 2.0
+Tested up to: 2.6
+Stable tag: 1.0
+
+Batcache uses Memcached to store and serve rendered pages.
+
+== Description ==
+
+Batcache uses Memcached to store and serve rendered pages. It's not as fast as Donncha's WP-Super-Cache but it can be used where file-based caching is not practical or not desired.
+
+Development testing showed a 40x reduction in page generation times: pages generated in 200ms were served from the cache in 5ms. Traffic simulations with Siege demonstrate that WordPress can handle up to twenty times more traffic with Batcache installed.
+
+Batcache is aimed at preventing a flood of traffic from breaking your site. It does this by serving old pages to new users. This reduces the demand on the web server CPU and the database. It also means some people may see a page that is a few minutes old. However this only applies to people who have not interacted with your web site before. Once they have logged in or left a comment they will always get fresh pages.
+
+Possible future features:
+
+* Comments, edits, and new posts will trigger cache regeneration
+* Online installation assistance
+* Configuration page
+* Stats
+
+== Installation ==
+
+1. Get the Memcached backend working. See below.
+
+1. Upload `advanced-cache.php` to the `/wp-content/` directory
+
+1. Add this line the top of `wp-config.php` to activate Batcache:
+
+`define('WP_CACHE', true);`
+
+1. Test by reloading a page in your browser several times and then viewing the source. Just above the `</head>` closing tag you should see some Batcache stats.
+
+1. Tweak the options near the top of `advanced-cache.php`
+
+1. *Optional* Upload `batcache.php` to the `/wp-content/plugins/` directory.
+
+= Memcached backend =
+
+1. Install [memcached](http://danga.com/memcached) on at least one server. Note the connection info. The default is `127.0.0.1:11211`.
+
+1. Install the [PECL memcached extension](http://pecl.php.net/package/memcache) and [Ryan's Memcached backend 2.0](http://svn.wp-plugins.org/memcached/trunk/). Use the [1.0 branch](http://svn.wp-plugins.org/memcached/branches/1.0/) if you don't have or can't install the PECL extension.
+
+== Frequently Asked Questions ==
+
+= Should I use this? =
+
+Batcache can be used anywhere Memcached is available. WP-Super-Cache is preferred for most blogs. If you have more than one web server, try Batcache.
+
+= Why was this written? =
+
+Batcache was written to help WordPress.com cope with the massive and prolonged traffic spike on Gizmodo's live blog during Apple events. Live blogs were famous for failing under the load of traffic. Gizmodo's live blog stays up because of Batcache.
+
+Actually all of WordPress.com stays up during Apple events because of Batcache. The traffic is twice the average during Apple events. But the web servers and databases barely feel the difference.
+
+= What does it have to do with bats? =
+
+Batcache was named "supercache" when it was written. (It's still called that on WordPress.com.) A few months later, while "supercache" was still private, Donncha released the WP-Super-Cache plugin. It wouldn't be fun to dispute the name or create confusion for users so a name change seemed best. The move from "Super" to "Bat" was inspired by comic book heroes. It has nothing to do with the fact that the author's city is home to the [world's largest urban bat colony](http://www.batcon.org/home/index.asp?idPage=122).
+

--- a/readme.txt
+++ b/readme.txt
@@ -1,15 +1,15 @@
 === Batcache ===
-Contributors: andy
-Tags: cache, memcached, speed, performance, digg
-Requires at least: 2.0
-Tested up to: 3.3.1
-Stable tag: 1.0
+Contributors: automattic, andy, orensol, markjaquith, vnsavage, batmoo, yoavf
+Tags: cache, memcache, memcached, speed, performance, load, server
+Requires at least: 3.2
+Tested up to: 3.5
+Stable tag: 1.2
 
 Batcache uses Memcached to store and serve rendered pages.
 
 == Description ==
 
-Batcache uses Memcached to store and serve rendered pages. It's not as fast as Donncha's WP-Super-Cache but it can be used where file-based caching is not practical or not desired.
+Batcache uses Memcached to store and serve rendered pages. It can also optionally cache redirects. It's not as fast as Donncha's WP-Super-Cache but it can be used where file-based caching is not practical or not desired. For instance, any site that is run on more than one server should use Batcache because it allows all servers to use the same storage.
 
 Development testing showed a 40x reduction in page generation times: pages generated in 200ms were served from the cache in 5ms. Traffic simulations with Siege demonstrate that WordPress can handle up to twenty times more traffic with Batcache installed.
 
@@ -26,27 +26,23 @@ Possible future features:
 
 1. Get the Memcached backend working. See below.
 
-2. Upload `advanced-cache.php` to the `/wp-content/` directory
+1. Upload `advanced-cache.php` to the `/wp-content/` directory
 
-3. Add this line the top of `wp-config.php` to activate Batcache:
+1. Add this line the top of `wp-config.php` to activate Batcache:
 
 `define('WP_CACHE', true);`
 
-4. Test by reloading a page in your browser several times and then viewing the source. Just above the `</head>` closing tag you should see some Batcache stats.
+1. Test by reloading a page in your browser several times and then viewing the source. Just above the `</head>` closing tag you should see some Batcache stats.
 
-5. Tweak the options near the top of `advanced-cache.php`
+1. Tweak the options near the top of `advanced-cache.php`
 
-6. *Optional* Upload `batcache.php` to the `/wp-content/plugins/` directory.
-
-7. *Optional* Allow for Mobile User Agent Detection:
-
-Uncomment `$batcache->unique['mobile'] = is_mobile_user_agent();` And add a function called "is_mobile_user_agent" above your call to `define('WP_CACHE', true);` in `wp-config.php` (example function here: http://pastie.org/3239778).
+1. *Optional* Upload `batcache.php` to the `/wp-content/plugins/` directory.
 
 = Memcached backend =
 
 1. Install [memcached](http://danga.com/memcached) on at least one server. Note the connection info. The default is `127.0.0.1:11211`.
 
-2. Install the [PECL memcached extension](http://pecl.php.net/package/memcache) and [Ryan's Memcached backend 2.0](http://svn.wp-plugins.org/memcached/trunk/). Use the [1.0 branch](http://svn.wp-plugins.org/memcached/branches/1.0/) if you don't have or can't install the PECL extension.
+1. Install the [PECL memcached extension](http://pecl.php.net/package/memcache) and [Ryan's Memcached backend 2.0](http://svn.wp-plugins.org/memcached/trunk/). Use the [1.0 branch](http://svn.wp-plugins.org/memcached/branches/1.0/) if you don't have or can't install the PECL extension.
 
 == Frequently Asked Questions ==
 
@@ -64,3 +60,10 @@ Actually all of WordPress.com stays up during Apple events because of Batcache. 
 
 Batcache was named "supercache" when it was written. (It's still called that on WordPress.com.) A few months later, while "supercache" was still private, Donncha released the WP-Super-Cache plugin. It wouldn't be fun to dispute the name or create confusion for users so a name change seemed best. The move from "Super" to "Bat" was inspired by comic book heroes. It has nothing to do with the fact that the author's city is home to the [world's largest urban bat colony](http://www.batcon.org/home/index.asp?idPage=122).
 
+== Changelog ==
+
+= trunk =
+* Add REQUEST_METHOD to the cache keys. Prevents GET requests receiving bodyless HEAD responses. This change invalidates the entire cache at upgrade time.
+
+= 1.1 =
+* Many bugfixes and updates from trunk


### PR DESCRIPTION
It's not uncommon that when redirects are sent, the Cache-Control also has `max-age`. This is respected by Batcache, which isn't a great default. Even when `$batcache->cache_redirects` is enabled, the `max-age=0` takes precedence. This PR changes that behaviour to cache redirects regardless of the `max-age=X` in the Cache Control header.
